### PR TITLE
feat: implement email queuing for event booking submissions

### DIFF
--- a/backend/emails/internal/emails/admin_new_event/admin_new_event_test.go
+++ b/backend/emails/internal/emails/admin_new_event/admin_new_event_test.go
@@ -113,9 +113,12 @@ func TestReplyTo(t *testing.T) {
 func TestRender(t *testing.T) {
 	metadata := map[string]interface{}{
 		"eventId":       "evt_123",
+		"fullName":      "Mario Rossi",
 		"customerEmail": "customer@example.com",
+		"phone":         "0123456789",
+		"description":   "Evento di compleanno per 15 persone",
 		"eventDate":     "2025-12-01",
-		"eventType":     "Wedding",
+		"association":   "Associazione ricreativa",
 	}
 	adminEmails := []string{"admin@test.com"}
 
@@ -130,15 +133,27 @@ func TestRender(t *testing.T) {
 		t.Error("Body should contain eventId")
 	}
 
+	if !strings.Contains(body, "Mario Rossi") {
+		t.Error("Body should contain fullName")
+	}
+
 	if !strings.Contains(body, "customer@example.com") {
 		t.Error("Body should contain customerEmail")
+	}
+
+	if !strings.Contains(body, "0123456789") {
+		t.Error("Body should contain phone")
+	}
+
+	if !strings.Contains(body, "Evento di compleanno per 15 persone") {
+		t.Error("Body should contain description")
 	}
 
 	if !strings.Contains(body, "2025-12-01") {
 		t.Error("Body should contain eventDate")
 	}
 
-	if !strings.Contains(body, "Wedding") {
-		t.Error("Body should contain eventType")
+	if !strings.Contains(body, "Associazione ricreativa") {
+		t.Error("Body should contain association")
 	}
 }

--- a/backend/emails/internal/emails/admin_new_event/template.txt
+++ b/backend/emails/internal/emails/admin_new_event/template.txt
@@ -3,9 +3,16 @@ Nuova Richiesta Evento
 È stato inviato un nuovo evento che richiede la tua revisione:
 
 ID Evento: {{.eventId}}
-Richiedente: {{.customerEmail}}
-Data: {{.eventDate}}
-Tipo: {{.eventType}}
+
+Dati Richiedente:
+- Nome: {{.fullName}}
+- Email: {{.customerEmail}}
+- Telefono: {{.phone}}{{if .association}}
+- Associazione: {{.association}}{{end}}
+
+Dettagli Evento:
+- Data: {{.eventDate}}
+- Descrizione: {{.description}}
 
 Per favore accedi al pannello di amministrazione per revisionare questo evento.
 

--- a/backend/emails/internal/emails/customer_new_event/customer_new_event_test.go
+++ b/backend/emails/internal/emails/customer_new_event/customer_new_event_test.go
@@ -101,9 +101,11 @@ func TestReplyTo(t *testing.T) {
 func TestRender(t *testing.T) {
 	metadata := map[string]interface{}{
 		"eventId":       "evt_123",
+		"fullName":      "Mario Rossi",
 		"customerEmail": "customer@test.com",
+		"phone":         "0123456789",
+		"description":   "Evento di compleanno per 15 persone",
 		"eventDate":     "2025-12-01",
-		"eventType":     "Wedding",
 	}
 
 	email, _ := New(metadata)
@@ -117,11 +119,23 @@ func TestRender(t *testing.T) {
 		t.Error("Body should contain eventId")
 	}
 
-	if !strings.Contains(body, "2025-12-01") {
-		t.Error("Body should contain eventDate")
+	if !strings.Contains(body, "Mario Rossi") {
+		t.Error("Body should contain fullName")
 	}
 
-	if !strings.Contains(body, "Wedding") {
-		t.Error("Body should contain eventType")
+	if !strings.Contains(body, "customer@test.com") {
+		t.Error("Body should contain customerEmail")
+	}
+
+	if !strings.Contains(body, "0123456789") {
+		t.Error("Body should contain phone")
+	}
+
+	if !strings.Contains(body, "Evento di compleanno per 15 persone") {
+		t.Error("Body should contain description")
+	}
+
+	if !strings.Contains(body, "2025-12-01") {
+		t.Error("Body should contain eventDate")
 	}
 }

--- a/backend/emails/internal/emails/customer_new_event/template.txt
+++ b/backend/emails/internal/emails/customer_new_event/template.txt
@@ -1,11 +1,14 @@
 Richiesta Evento Confermata
 
+Ciao {{.fullName}},
+
 Grazie per aver inviato la richiesta per il tuo evento!
 
-ID Evento: {{.eventId}}
-Data: {{.eventDate}}
-Tipo: {{.eventType}}
+Riepilogo Richiesta:
+- ID Riferimento: {{.eventId}}
+- Data Evento: {{.eventDate}}
+- Descrizione: {{.description}}
 
-Esamineremo la tua richiesta e ti contatteremo a breve.
+Esamineremo la tua richiesta e ti contatteremo a breve all'indirizzo {{.customerEmail}} o al numero {{.phone}}.
 
 Non puoi rispondere direttamente a questa email.

--- a/backend/eventform/go.mod
+++ b/backend/eventform/go.mod
@@ -5,15 +5,17 @@ go 1.25.3
 require (
 	github.com/99designs/gqlgen v0.17.81
 	github.com/aws/aws-lambda-go v1.50.0
+	github.com/aws/aws-sdk-go-v2 v1.40.1
+	github.com/aws/aws-sdk-go-v2/config v1.32.3
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.18
 	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2
 	github.com/daniele/gestione-caselo/backend v0.0.0-00010101000000-000000000000
+	github.com/google/uuid v1.6.0
 	github.com/vektah/gqlparser/v2 v2.5.30
 )
 
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.40.1 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.15 // indirect
@@ -29,7 +31,6 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect

--- a/backend/eventform/go.sum
+++ b/backend/eventform/go.sum
@@ -32,6 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.15 h1:3/u/4yZO
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.15/go.mod h1:4Zkjq0FKjE78NKjabuM4tRXKFzUJWXgP0ItEZK8l7JU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.3 h1:d/6xOGIllc/XW1lzG9a4AUBMmpLA9PXcQnVPTuHHcik=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.3/go.mod h1:fQ7E7Qj9GiW8y0ClD7cUJk3Bz5Iw8wZkWDHsTe8vDKs=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.18 h1:zHL8HTKRbiJ2UfQdjeszQtPp9cHFeuwZqFB5/C02FGs=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.18/go.mod h1:Ii4ZZhKuXo8+is8A+9AZo2vXeCfFJyR+pXHUromSz+U=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.5 h1:YKGgwB1rye0JpV10Bfma3cZdQzX61j2HPWQw+YxWvrQ=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.67.5/go.mod h1:eBDSa0vuYB0lalpNxavIw80Q4Ksy08bhHHbT0aWa4tE=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.6 h1:8sTTiw+9yuNXcfWeqKF2x01GqCF49CpP4Z9nKrrk/ts=

--- a/backend/eventform/internal/graphql/resolver.go
+++ b/backend/eventform/internal/graphql/resolver.go
@@ -1,7 +1,25 @@
 package graphql
 
+import (
+	"context"
+
+	"github.com/daniele/gestione-caselo/backend/eventform/internal/queue"
+)
+
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
 
-type Resolver struct{}
+type QueueClient interface {
+	SendEmailMessage(ctx context.Context, msg queue.EmailMessage) error
+}
+
+type Resolver struct {
+	queueClient QueueClient
+}
+
+func NewResolver(queueClient QueueClient) *Resolver {
+	return &Resolver{
+		queueClient: queueClient,
+	}
+}

--- a/backend/eventform/internal/graphql/resolver_test.go
+++ b/backend/eventform/internal/graphql/resolver_test.go
@@ -6,10 +6,26 @@ import (
 
 	"github.com/daniele/gestione-caselo/backend/eventform/internal/graphql"
 	"github.com/daniele/gestione-caselo/backend/eventform/internal/graphql/model"
+	"github.com/daniele/gestione-caselo/backend/eventform/internal/queue"
 )
 
+type mockQueueClient struct {
+	messages []queue.EmailMessage
+}
+
+func (m *mockQueueClient) SendEmailMessage(ctx context.Context, msg queue.EmailMessage) error {
+	m.messages = append(m.messages, msg)
+	return nil
+}
+
+func newMockQueueClient() *mockQueueClient {
+	return &mockQueueClient{
+		messages: make([]queue.EmailMessage, 0),
+	}
+}
+
 func TestHelloQuery(t *testing.T) {
-	resolver := &graphql.Resolver{}
+	resolver := graphql.NewResolver(nil)
 
 	result, err := resolver.Query().Hello(context.Background())
 
@@ -132,7 +148,8 @@ func TestSubmitEventBooking(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := &graphql.Resolver{}
+			mockQueue := newMockQueueClient()
+			resolver := graphql.NewResolver(mockQueue)
 
 			result, err := resolver.Mutation().SubmitEventBooking(context.Background(), tt.input)
 
@@ -157,6 +174,30 @@ func TestSubmitEventBooking(t *testing.T) {
 
 			if result.Message == "" {
 				t.Errorf("SubmitEventBooking() message is empty")
+			}
+
+			// Verify that two email messages were queued
+			if len(mockQueue.messages) != 2 {
+				t.Errorf("Expected 2 email messages to be queued, got %d", len(mockQueue.messages))
+			}
+
+			// Verify admin email was queued
+			foundAdmin := false
+			foundCustomer := false
+			for _, msg := range mockQueue.messages {
+				if msg.Template == "admin_new_event" {
+					foundAdmin = true
+				}
+				if msg.Template == "customer_new_event" {
+					foundCustomer = true
+				}
+			}
+
+			if !foundAdmin {
+				t.Error("admin_new_event email was not queued")
+			}
+			if !foundCustomer {
+				t.Error("customer_new_event email was not queued")
 			}
 		})
 	}

--- a/backend/eventform/internal/graphql/schema.resolvers.go
+++ b/backend/eventform/internal/graphql/schema.resolvers.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 
 	"github.com/daniele/gestione-caselo/backend/eventform/internal/graphql/model"
+	"github.com/daniele/gestione-caselo/backend/eventform/internal/queue"
+	"github.com/google/uuid"
 )
 
 // SubmitEventBooking is the resolver for the submitEventBooking field.
@@ -34,7 +36,40 @@ func (r *mutationResolver) SubmitEventBooking(ctx context.Context, input model.E
 		return nil, fmt.Errorf("acceptData must be true")
 	}
 
-	// TODO: Queue email jobs for admin and customer
+	// Generate event ID
+	eventID := uuid.New().String()
+
+	// Prepare metadata for email templates
+	metadata := map[string]interface{}{
+		"eventId":       eventID,
+		"fullName":      input.FullName,
+		"customerEmail": input.Email,
+		"phone":         input.Phone,
+		"description":   input.Description,
+		"eventDate":     input.Date,
+	}
+
+	if input.Association != nil {
+		metadata["association"] = *input.Association
+	}
+
+	// Queue admin notification email
+	adminEmail := queue.EmailMessage{
+		Template: "admin_new_event",
+		Metadata: metadata,
+	}
+	if err := r.queueClient.SendEmailMessage(ctx, adminEmail); err != nil {
+		return nil, fmt.Errorf("failed to queue admin email: %w", err)
+	}
+
+	// Queue customer confirmation email
+	customerEmail := queue.EmailMessage{
+		Template: "customer_new_event",
+		Metadata: metadata,
+	}
+	if err := r.queueClient.SendEmailMessage(ctx, customerEmail); err != nil {
+		return nil, fmt.Errorf("failed to queue customer email: %w", err)
+	}
 
 	return &model.EventBookingResponse{
 		Success: true,

--- a/backend/eventform/internal/queue/queue.go
+++ b/backend/eventform/internal/queue/queue.go
@@ -1,0 +1,44 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+type Client struct {
+	sqsClient *sqs.Client
+	queueURL  string
+}
+
+func New(sqsClient *sqs.Client, queueURL string) *Client {
+	return &Client{
+		sqsClient: sqsClient,
+		queueURL:  queueURL,
+	}
+}
+
+type EmailMessage struct {
+	Template string                 `json:"template"`
+	Metadata map[string]interface{} `json:"metadata"`
+}
+
+func (c *Client) SendEmailMessage(ctx context.Context, msg EmailMessage) error {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %w", err)
+	}
+
+	_, err = c.sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:    aws.String(c.queueURL),
+		MessageBody: aws.String(string(body)),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send SQS message: %w", err)
+	}
+
+	return nil
+}

--- a/backend/eventform/main.go
+++ b/backend/eventform/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,8 +10,11 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
 	"github.com/daniele/gestione-caselo/backend/eventform/internal/graphql"
+	"github.com/daniele/gestione-caselo/backend/eventform/internal/queue"
 	appconfig "github.com/daniele/gestione-caselo/backend/internal/config"
 )
 
@@ -32,9 +36,29 @@ func corsMiddlewareWithConfig(origins string) func(http.Handler) http.Handler {
 }
 
 func main() {
+	ctx := context.Background()
 	origins := appconfig.GetEnvVariable("ALLOWED_ORIGINS")
+	queueURL := appconfig.GetEnvVariable("SQS_QUEUE_URL")
 
-	srv := handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.Config{Resolvers: &graphql.Resolver{}}))
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		log.Fatalf("Failed to load AWS config: %v", err)
+	}
+
+	// Configure SQS client with custom endpoint if AWS_ENDPOINT_URL is set
+	var sqsClient *sqs.Client
+	if endpointURL := os.Getenv("AWS_ENDPOINT_URL"); endpointURL != "" {
+		sqsClient = sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+			o.BaseEndpoint = &endpointURL
+		})
+	} else {
+		sqsClient = sqs.NewFromConfig(cfg)
+	}
+
+	queueClient := queue.New(sqsClient, queueURL)
+
+	resolver := graphql.NewResolver(queueClient)
+	srv := handler.NewDefaultServer(graphql.NewExecutableSchema(graphql.Config{Resolvers: resolver}))
 
 	mux := http.NewServeMux()
 	mux.Handle("/", playground.Handler("GraphQL playground", "/graphql"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - AWS_REGION=eu-south-1
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
+      - SQS_QUEUE_URL=http://elasticmq:9324/000000000000/emails
+      - AWS_ENDPOINT_URL=http://elasticmq:9324
+    depends_on:
+      - elasticmq
     volumes:
       - ./backend/eventform:/app
     networks:

--- a/terraform/states/lambda/iam.tf
+++ b/terraform/states/lambda/iam.tf
@@ -89,6 +89,24 @@ resource "aws_iam_role_policy" "eventform_ssm" {
   })
 }
 
+resource "aws_iam_role_policy" "eventform_sqs" {
+  name = "sqs-send"
+  role = aws_iam_role.eventform.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:SendMessage"
+        ]
+        Resource = module.queues.emails_arn
+      }
+    ]
+  })
+}
+
 # IAM role for emails Lambda
 resource "aws_iam_role" "emails" {
   name = "${local.prefix}-emails"


### PR DESCRIPTION
Implement complete email queuing workflow for event booking submissions. When a booking is submitted via GraphQL, the system now queues two email messages (admin notification and customer confirmation) to SQS for asynchronous processing.

Backend Changes:
- Created queue package for SQS message sending
- Updated GraphQL resolver to queue both admin and customer emails
- Added QueueClient interface for dependency injection
- Generated UUID for each booking submission
- Added SQS send permissions to eventform Lambda IAM role
- Map form fields to email metadata (fullName, phone, description, association)

Email Template Updates:
- Updated admin_new_event template to include all form fields
- Updated customer_new_event template to include all form fields
- Removed generic eventType field in favor of detailed description
- Added conditional rendering for optional association field

Tests:
- Updated email tests to reflect new template structure
- Added mock queue client for GraphQL resolver tests
- Verified both emails are queued on successful submission
- All tests passing

Infrastructure:
- SQS_QUEUE_URL already configured in Terraform
- Added SQS SendMessage permission to eventform IAM role

🤖 Generated with [Claude Code](https://claude.com/claude-code)